### PR TITLE
Add be.AssignedAs and deprecate be.Panic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.57.2
+          version: v1.62.2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,7 +20,6 @@ linters:
     - errchkjson
     - errname
     - errorlint
-    - exportloopref
     - gocognit
     - gocritic
     - gofumpt

--- a/README.md
+++ b/README.md
@@ -109,8 +109,6 @@ g.Should(be.DeepEqual([]string{"a", "b"}, []string{"a", "b"}))
 g.Should(be.SliceContaining([]int{1, 2, 3}, 2))
 g.Should(be.StringContaining("foobar", "foo"))
 
-g.Should(be.Panic(func() { panic("oh no") }))
-
 var err error
 g.NoError(err)
 g.Must(be.Nil(err))
@@ -201,6 +199,24 @@ And instantly get helpful, descriptive error messages:
 ```go
 g.Should(BeThirteen(myInt)) // "myInt is 0"
 g.Should(BeThirteen(5 + 6)) // "5 + 6 is 11"
+```
+
+#### Handling Panics
+
+If you expect your code to panic, it is better to assert that the value passed
+to `panic` has the properties you expect, rather than to make an assumption
+that the panic you encountered is the panic you were expecting. Ghost can be
+combined with `defer`/`recover` to access the full expressiveness of test
+assertions:
+
+```go
+defer func() {
+	var err error
+	g.Must(be.AssignedAs(recover(), &err))
+	g.Should(be.ErrorEqual(err, "a specific error occurred"))
+}()
+
+doStuff()
 ```
 
 ## Philosophy

--- a/example_test.go
+++ b/example_test.go
@@ -27,9 +27,6 @@ func TestExample(t *testing.T) {
 
 	g.Should(be.StringContaining("foobar", "foo"))
 
-	g.Should(be.Panic(func() { panic("oh no") }))
-	g.ShouldNot(be.Panic(func() {}))
-
 	var err error
 	g.NoError(err)
 	g.Must(be.Nil(err))
@@ -42,6 +39,19 @@ func TestExample(t *testing.T) {
 
 	g.Should(be.JSONEqual(`{"b": 1, "a": 0}`, `{"a": 0, "b": 1}`))
 	g.ShouldNot(be.JSONEqual(`{"a":1}`, `{"a":2}`))
+}
+
+func ExampleAssignedAs() {
+	t := new(testing.T) // from the test
+	g := ghost.New(t)
+
+	defer func() {
+		var err error
+		g.Must(be.AssignedAs(recover(), &err))
+		g.Should(be.ErrorEqual(err, "oops"))
+	}()
+
+	panic(errors.New("oops"))
 }
 
 func ExampleEventually() {

--- a/tusk.yml
+++ b/tusk.yml
@@ -9,7 +9,7 @@ tasks:
     usage: Run static analysis
     description: |
       Run golangci-lint using the project configuration.
-    run: go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.1 run ./...
+    run: go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2 run ./...
 
   test:
     usage: Run unit tests


### PR DESCRIPTION
I don't think the current panic assertion is very good, because asserting _that_ something panics is a lot less effective than asserting the _value_ of a panic. So this refactor makes it so you have to orchestrate the panic recovery yourself, but also makes it easier to assert something of type `any` with a more specific assertion.

And generally I think `be.AssignedAs` is a smart assertion to have. It roughly resembles the shape of `be.ErrorAs`, so it shouldn't be very surprising.